### PR TITLE
Use build-in HeaderGetters#bearerToken method

### DIFF
--- a/booker-service/src/main/scala/com/adrianfilip/booker/bk/infrastructure/authentication/AuthenticationOperations.scala
+++ b/booker-service/src/main/scala/com/adrianfilip/booker/bk/infrastructure/authentication/AuthenticationOperations.scala
@@ -26,8 +26,7 @@ object AuthenticationOperations:
     for {
       authenticationService <- ZIO.service[AuthenticationService]
       token                 <- ZIO
-                                 .fromOption(request.headers.toList.find(kv => kv._1 == "Authorization"))
-                                 .map(_._2.replace("Bearer ", ""))
+                                 .fromOption(request.bearerToken)
                                  .orElseFail(OuterError.MissingAuthorizationToken(""))
       user                  <- authenticationService.authenticate(token)
     } yield user


### PR DESCRIPTION
zhttp's has build-in support to obtain the bearer token.
