### PR TITLE
Default implementation for find methods that should return an entity 

### DIFF
--- a/booker-service/src/main/scala/com/adrianfilip/booker/bk/domain/repository/BuildingRepository.scala
+++ b/booker-service/src/main/scala/com/adrianfilip/booker/bk/domain/repository/BuildingRepository.scala
@@ -9,7 +9,8 @@ trait BuildingRepository:
   def findAll: UIO[List[Building]]
   def findLike(likeFilter: LikeFilter): UIO[List[Building]]
   def findById(id: String): UIO[Option[Building]]
-  def get(id: String): IO[BuildingNotFound, Building]
+  def get(id: String): IO[BuildingNotFound, Building] =
+    findById(id).someOrFail(BuildingNotFound(id))
   def add(m: AddBuilding): IO[BuildingCodeAlreadyUsed, Unit]
   def update(m: Building): IO[BuildingNotFound | BuildingCodeAlreadyUsed, Unit]
   def delete(id: String): IO[BuildingNotFound, Unit]

--- a/booker-service/src/main/scala/com/adrianfilip/booker/bk/domain/repository/UserRepository.scala
+++ b/booker-service/src/main/scala/com/adrianfilip/booker/bk/domain/repository/UserRepository.scala
@@ -6,7 +6,8 @@ import zio.{IO, UIO, ZIO}
 
 trait UserRepository:
   def findByUsername(username: String): UIO[Option[UserE]]
-  def get(username: String): IO[UserNotFound, UserE]
+  def get(username: String): IO[UserNotFound, UserE] =
+    findByUsername(username).someOrFail(UserNotFound(username))
 
 object UserRepository:
 

--- a/booker-service/src/main/scala/com/adrianfilip/booker/bk/infrastructure/domain/repository/UserRepositoryMock.scala
+++ b/booker-service/src/main/scala/com/adrianfilip/booker/bk/infrastructure/domain/repository/UserRepositoryMock.scala
@@ -30,7 +30,4 @@ object UserRepositoryMock:
 
       override def findByUsername(username: String): UIO[Option[UserRepository.UserE]] =
         ZIO.succeed(users.find(_.username == username))
-
-      override def get(username: String): IO[AuthenticationDomainError.UserNotFound, UserRepository.UserE] =
-        ZIO.fromOption(users.find(_.username == username)).orElseFail(UserNotFound(username))
     )

--- a/booker-service/src/main/scala/com/adrianfilip/booker/bk/infrastructure/domain/repository/mocks/BuildingRepositoryMock.scala
+++ b/booker-service/src/main/scala/com/adrianfilip/booker/bk/infrastructure/domain/repository/mocks/BuildingRepositoryMock.scala
@@ -76,12 +76,6 @@ object BuildingRepositoryMock:
           } yield ()
         }
 
-      override def get(id: String): IO[BuildingNotFound, Building] =
-        buildingsDb.get
-          .map(_.values.toList.find(_.uuid == id))
-          .flatMap(STM.fromOption(_).orElseFail(BuildingNotFound(id)))
-          .commit
-
       override def findLike(filters: LikeFilter): UIO[List[Building]] =
         buildingsDb.get
           .map(_.values.toList.filter { b =>


### PR DESCRIPTION
Provide a default implementation for finder methods (on repositories) that must return an entity or fail